### PR TITLE
Feat/add and delete review

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ When setting routes in `routes.php` make sure that:
 
 # Unsere Termine
 ### Erster Pflicht-Besprechungstermin
-📅 07.05.2025 </br>
+📅 30.04.2025 </br>
 🕞 15:25 Uhr
 - [ ] done?
 

--- a/add-review.php
+++ b/add-review.php
@@ -1,0 +1,56 @@
+<?php
+// Session starten, aber nur wenn noch keine läuft
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+// TEST: Temporär gesetzter Nutzer (für Tests, bis Login existiert)
+$_SESSION['customerId'] = 1;
+
+// Prüfen, ob User gesetzt ist (sicherheitscheck)
+if (!isset($_SESSION['customerId'])) {
+    die("Not logged in – customerId missing in session.");
+}
+
+require_once "bootstrap.php"; // Initialisiert DB & Klassen
+require_once "classes/Review.php";
+require_once "repositories/ReviewRepository.php";
+
+// Formulardaten holen
+$artworkId = $_POST['artworkId'] ?? null;
+$customerId = $_SESSION['customerId'];
+$rating = isset($_POST['rating']) ? (int)$_POST['rating'] : null;
+$comment = trim($_POST['comment'] ?? '');
+
+// Validierung
+if (!$artworkId || !$rating || $rating < 1 || $rating > 5 || empty($comment)) {
+    die("Invalid review data.");
+}
+
+// DB und Repository initialisieren
+$db = new Database();
+$repo = new ReviewRepository($db);
+
+// Prüfen, ob der User dieses Artwork schon bewertet hat
+if ($repo->hasUserReviewed($customerId, $artworkId)) {
+    die("You have already reviewed this artwork.");
+}
+
+// Review-Objekt erstellen
+$review = new Review(
+    null,                      // ReviewId (wird von DB generiert)
+    $artworkId,
+    $customerId,
+    date('Y-m-d H:i:s'), 
+    $rating,
+    $comment
+);
+
+// In DB speichern
+$repo->addReview($review);
+
+// Zurück zur Artwork-Seite
+header("Location: " . $_SERVER['HTTP_REFERER']);
+exit;
+
+

--- a/classes/Review.php
+++ b/classes/Review.php
@@ -10,20 +10,21 @@ class Review
     private $reviewDate;
 
     public function __construct(
-        $customerId,
+        $reviewId = null,
         $artworkId,
-        $rating,
-        $comment,
+        $customerId,
         $reviewDate = null,
-        $reviewId = null
+        $rating,
+        $comment
     ) {
-        $this->setCustomerId($customerId);
+        $this->setReviewId($reviewId);
         $this->setArtworkId($artworkId);
+        $this->setCustomerId($customerId);
+        $this->setReviewDate($reviewDate);
         $this->setRating($rating);
         $this->setComment($comment);
-        $this->setReviewDate($reviewDate);
-        $this->setReviewId($reviewId);
     }
+    
 
 
 

--- a/delete-review.php
+++ b/delete-review.php
@@ -1,25 +1,30 @@
 <?php
 session_start();
 
-// Only allow admins
-if (!($_SESSION['isAdmin'] ?? false)) {
-    die("Unauthorized access");
-}
-
 require_once "bootstrap.php";
 require_once "repositories/ReviewRepository.php";
+
+// Only allow admin users
+if (!($_SESSION['isAdmin'] ?? false)) {
+    header("Location: error.php?error=unauthorized");
+    exit;
+}
 
 $reviewId = $_POST['reviewId'] ?? null;
 $artworkId = $_POST['artworkId'] ?? null;
 
+// Validate form data
 if (!$reviewId || !$artworkId) {
-    die("Missing data");
+    header("Location: error.php?error=missingReviewData");
+    exit;
 }
 
 $db = new Database();
 $repo = new ReviewRepository($db);
+
+// Delete the review
 $repo->deleteReview($reviewId);
 
-// Redirect back to artist page
+// Redirect back to previous page
 header("Location: " . $_SERVER['HTTP_REFERER']);
 exit;

--- a/delete-review.php
+++ b/delete-review.php
@@ -1,0 +1,25 @@
+<?php
+session_start();
+
+// Only allow admins
+if (!($_SESSION['isAdmin'] ?? false)) {
+    die("Unauthorized access");
+}
+
+require_once "bootstrap.php";
+require_once "repositories/ReviewRepository.php";
+
+$reviewId = $_POST['reviewId'] ?? null;
+$artworkId = $_POST['artworkId'] ?? null;
+
+if (!$reviewId || !$artworkId) {
+    die("Missing data");
+}
+
+$db = new Database();
+$repo = new ReviewRepository($db);
+$repo->deleteReview($reviewId);
+
+// Redirect back to artist page
+header("Location: " . $_SERVER['HTTP_REFERER']);
+exit;

--- a/display-single-artist.php
+++ b/display-single-artist.php
@@ -1,118 +1,113 @@
 <!DOCTYPE html>
+<?php
+session_start();
+$_SESSION['customerId'] = 1; // TEMP: simulate logged in user
+?>
+
 <html lang="en">
 
 <?php
-    require_once dirname(__DIR__)."/src/head.php";
-require_once dirname(__DIR__)."/src/repositories/ArtistRepository.php";
-require_once dirname(__DIR__)."/src/repositories/ArtworkRepository.php";
-require_once dirname(__DIR__)."/src/navbar.php";
+require_once dirname(__DIR__) . "/src/head.php";
+require_once dirname(__DIR__) . "/src/repositories/ArtistRepository.php";
+require_once dirname(__DIR__) . "/src/repositories/ArtworkRepository.php";
+require_once dirname(__DIR__) . "/src/navbar.php";
 
 $db = new Database();
 $artistRepository = new ArtistRepository($db);
 $artworkRepository = new ArtworkRepository($db);
 
-// Checks if id is set correctly in URL
+// Check if artist ID is valid
 if (isset($_GET['id']) && is_numeric($_GET['id'])) {
-    $artistId = $_GET['id'];
+	$artistId = $_GET['id'];
 } else {
-    header("Location: /error.php?error=invalidParam");
-    exit();
+	header("Location: /error.php?error=invalidParam");
+	exit();
 }
 
-// Checks if artist exists in database
+// Load artist and artworks
 try {
-    $artist = $artistRepository->getArtistById($artistId);
-    $artworks = $artworkRepository->getArtworksByArtist($artistId);
+	$artist = $artistRepository->getArtistById($artistId);
+	$artworks = $artworkRepository->getArtworksByArtist($artistId);
 } catch (Exception $e) {
-    header("Location: /error.php?error=invalidID&type=artist");
-    exit();
+	header("Location: /error.php?error=invalidID&type=artist");
+	exit();
 }
 ?>
 
 <body class="container">
 	<br>
-	<h1> <?php echo $artist->getFirstName()?> <?php echo $artist->getLastName()?> </h1>
+	<h1><?php echo $artist->getFirstName() ?> <?php echo $artist->getLastName() ?></h1>
 	<div class="container mt-3">
 		<div class="row">
 			<div>
-				<!-- Displays artist image -->
-					<!-- Checks if artists' image exists -->
-					<?php $imagePath =  "/assets/images/artists/medium/".$artist->getArtistId().".jpg";
-$placeholderPath = "/assets/placeholder/artists/medium/placeholder.svg";
-if (file_exists($_SERVER['DOCUMENT_ROOT'] . $imagePath)) {
-    $correctImagePath = $imagePath;
-} else {
-    $correctImagePath = $placeholderPath;
-}
-?>
-					<img src="<?php echo $correctImagePath?>" alt="Bild von <?php echo $artist->getFirstName().' '.$artist->getLastName()?>">
-				</div>
-				<div class="col-md-8">
-					<!-- Displays artist description -->
-					<p><?php echo $artist->getDetails()?></p>
+				<!-- Artist image -->
+				<?php
+				$imagePath = "/assets/images/artists/medium/" . $artist->getArtistId() . ".jpg";
+				$placeholderPath = "/assets/placeholder/artists/medium/placeholder.svg";
+				$correctImagePath = file_exists($_SERVER['DOCUMENT_ROOT'] . $imagePath) ? $imagePath : $placeholderPath;
+				?>
+				<img src="<?php echo $correctImagePath ?>" alt="Image of <?php echo $artist->getFirstName() . ' ' . $artist->getLastName() ?>">
+			</div>
+			<div class="col-md-8">
+				<p><?php echo $artist->getDetails() ?></p>
 
-					<!-- Add to favourites button -->
-					<form method="post" action="/add-favourite.php">
-					<input type="hidden" name="artistId" value="<?php echo $artist->getArtistId()?>">
-						<button type="submit" class="btn btn-primary mt-2">Add to Favourites</button>
-					</form>
+				<!-- Add to favourites button -->
+				<form method="post" action="add-favourite.php">
+					<input type="hidden" name="artistId" value="<?php echo $artist->getArtistId() ?>">
+					<button type="submit" class="btn btn-primary mt-2">Add to Favourites</button>
+				</form>
 
-					<!-- Table with artist details -->
-					<table class="table table-bordered w-75 mt-4">
-						<thead class="thead-dark">
-							<tr>
-								<th colspan="2">Artist Details</th>
-							</tr>
-							</thead>
-							<tr>
-								<th>Date:</th>
-								<td><?php echo $artist->getYearOfBirth()?><?php if ($artist->getYearOfDeath()) {
-								    echo " - " . $artist->getYearOfDeath();
-								}?></td>
-							</tr>
-							<tr>
-								<th>Nationality:</th>
-								<td><?php echo $artist->getNationality()?></td>
-							</tr>
-							<tr>
-								<th>More Info:</th>
-								<td><a href="<?php echo $artist->getArtistLink()?>" target="_blank">Wikipedia</a></td>
-							</tr>
-					</table>
+				<!-- Artist details -->
+				<table class="table table-bordered w-75 mt-4">
+					<thead class="thead-dark">
+						<tr><th colspan="2">Artist Details</th></tr>
+					</thead>
+					<tr>
+						<th>Date:</th>
+						<td><?php echo $artist->getYearOfBirth() ?><?php if ($artist->getYearOfDeath()) echo " - " . $artist->getYearOfDeath() ?></td>
+					</tr>
+					<tr>
+						<th>Nationality:</th>
+						<td><?php echo $artist->getNationality() ?></td>
+					</tr>
+					<tr>
+						<th>More Info:</th>
+						<td><a href="<?php echo $artist->getArtistLink() ?>" target="_blank">Wikipedia</a></td>
+					</tr>
+				</table>
+			</div>
+		</div>
+
+		<h2 class="mt-5">Artworks by <?php echo $artist->getFirstName() ?> <?php echo $artist->getLastName() ?></h2>
+		<div class="row mt-4">
+			<?php foreach ($artworks as $artwork): ?>
+				<?php $artworkLink = "/display-single-artwork.php?id=" . $artwork->getArtworkId(); ?>
+				<div class="col-md-3 mb-4">
+					<div class="card h-100">
+						<!-- Artwork image -->
+						<?php
+						$imagePath = "/assets/images/works/square-medium/" . $artwork->getImageFileName() . ".jpg";
+						$placeholderPath = "/assets/placeholder/works/square-medium/placeholder.svg";
+						$correctImagePath = file_exists($_SERVER['DOCUMENT_ROOT'] . $imagePath) ? $imagePath : $placeholderPath;
+						?>
+						<a href="<?php echo $artworkLink ?>" target="_blank">
+							<img src="<?php echo $correctImagePath ?>" class="card-img-top" alt="<?php echo $artwork->getTitle() ?>">
+						</a>
+
+						<div class="card-body d-flex flex-column">
+							<h5 class="card-title text-center">
+								<a href="<?php echo $artworkLink ?>" target="_blank" class="text-body">
+									<?php echo $artwork->getTitle() ?>
+								</a>
+							</h5>
+							<a href="<?php echo $artworkLink ?>" target="_blank" class="btn btn-primary mt-auto">View</a>
+						</div>
+					</div>
 				</div>
-				</div>
-					<h2 class="mt-5">Artworks by <?php echo $artist->getFirstName()?> <?php echo $artist->getLastName()?></h2>
-					<div class="row mt-4">
-						<?php foreach ($artworks as $artwork):?>
-							<!-- Creates new URL to display single artwork --->
-							<?php $artworkLink = route('artworks', ['id' => $artwork->getArtworkId()])?>
-							<!-- List of artworks -->
-							<div class="col-md-3 mb-4">
-								<!-- Artwork card including image, name and view button --->
-								<div class="card h-100">
-									<!-- Checks if artworks' image exists -->
-									<?php $imagePath =  "/assets/images/works/square-medium/".$artwork->getImageFileName().".jpg";
-						    $placeholderPath = "/assets/placeholder/works/square-medium/placeholder.svg";
-						    if (file_exists($_SERVER['DOCUMENT_ROOT'] . $imagePath)) {
-						        $correctImagePath = $imagePath;
-						    } else {
-						        $correctImagePath = $placeholderPath;
-						    }
-						    ?>
-									<a href="<?php echo $artworkLink?>" target="_blank">
-									<img src="<?php echo $correctImagePath?>" class="card-img-top" alt="<?php echo $artwork->getTitle()?>">
-									</a>
-									<div class="card-body d-flex flex-column">
-										<h5 class="card-title text-center">
-											<a href="<?php echo $artworkLink?>" target="_blank" class="text-body"><?php echo $artwork->getTitle()?></a>
-										</h5>
-										<a href="<?php echo $artworkLink?>" target="_blank" class="btn btn-primary mt-auto">View</a>
-									</div>
-								</div>
-							</div>
-						<?php endforeach?>
+			<?php endforeach ?>
 		</div>
 	</div>
+
 	<?php require_once 'bootstrap.php'; ?>
 </body>
 </html>

--- a/display-single-artist.php
+++ b/display-single-artist.php
@@ -86,7 +86,11 @@ try {
 		<h2 class="mt-5">Artworks by <?php echo $artist->getFirstName() ?> <?php echo $artist->getLastName() ?></h2>
 		<div class="row mt-4">
 			<?php foreach ($artworks as $artwork): ?>
+
+
+				<!-- Creates new URL to display single artwork --->
 				<?php $artworkLink = "/display-single-artwork.php?id=" . $artwork->getArtworkId(); ?>
+				<!-- List of artworks -->
 				<div class="col-md-3 mb-4">
 					<div class="card h-100">
 						<!-- Artwork image -->
@@ -100,67 +104,6 @@ try {
 						</a>
 
 						<div class="card-body d-flex flex-column">
-							<!-- Checks if user is logged in -->
-							<?php if (isset($_SESSION['customerId'])): ?>
-
-								<!-- Loads ReviewRepository and checks if user already reviewed this artwork -->
-								<?php
-								require_once dirname(__DIR__) . "/src/repositories/ReviewRepository.php";
-								$reviewRepo = new ReviewRepository($db);
-								$alreadyReviewed = $reviewRepo->hasUserReviewed($_SESSION['customerId'], $artwork->getArtworkId());
-								?>
-
-								<!-- Displays review form if user has not reviewed yet -->
-								<?php if (!$alreadyReviewed): ?>
-									<form method="POST" action="add-review.php" class="mt-2">
-										<input type="hidden" name="artworkId" value="<?= $artwork->getArtworkId() ?>">
-										<label for="rating">Rating (1–5):</label>
-										<input type="number" name="rating" min="1" max="5" required class="form-control mb-1">
-										<label for="comment">Comment:</label>
-										<textarea name="comment" required class="form-control mb-2"></textarea>
-										<button type="submit" class="btn btn-sm btn-success">Submit Review</button>
-									</form>
-									<!-- Message if user has already submitted a review -->
-								<?php else: ?>
-									<p class="text-muted mt-2">You have already reviewed this artwork.</p>
-								<?php endif; ?>
-
-								<!-- Message if user is not logged in -->
-							<?php else: ?>
-								<p class="text-muted mt-2">Log in to leave a review.</p>
-							<?php endif; ?>
-
-							<!-- Loads and displays all reviews for this artwork -->
-							<?php
-							$reviews = $reviewRepo->getAllReviewsForArtwork($artwork->getArtworkId());
-							?>
-
-							<!-- If there are reviews, display them -->
-							<?php if (count($reviews) > 0): ?>
-								<div class="mt-3">
-									<h6>Reviews:</h6>
-									<?php foreach ($reviews as $review): ?>
-										<div class="border rounded p-2 mb-2 bg-light">
-											<strong>Rating:</strong> <?= $review->getRating() ?>/5<br>
-											<strong>Comment:</strong> <?= htmlspecialchars($review->getComment()) ?><br>
-											<small class="text-muted"><?= $review->getReviewDate() ?></small>
-											<!-- Show Delete button only for admins -->
-											<?php if ($_SESSION['isAdmin'] ?? false): ?>
-												<form method="POST" action="delete-review.php" onsubmit="return confirm('Are you sure you want to delete this review?')">
-													<input type="hidden" name="reviewId" value="<?= $review->getReviewId() ?>">
-													<input type="hidden" name="artworkId" value="<?= $review->getArtworkId() ?>">
-													<button type="submit" class="btn btn-sm btn-danger mt-2">Delete</button>
-												</form>
-											<?php endif; ?>
-
-										</div>
-									<?php endforeach; ?>
-								</div>
-								<!-- If no reviews exist -->
-							<?php else: ?>
-								<p class="text-muted mt-2">No reviews yet.</p>
-							<?php endif; ?>
-
 							<h5 class="card-title text-center">
 								<a href="<?php echo $artworkLink ?>" target="_blank" class="text-body">
 									<?php echo $artwork->getTitle() ?>

--- a/display-single-artist.php
+++ b/display-single-artist.php
@@ -1,7 +1,12 @@
 <!DOCTYPE html>
 <?php
 session_start();
-$_SESSION['customerId'] = 1; // TEMP: simulate logged in user
+
+
+$_SESSION['customerId'] = 1; // TEST-Nutzer ID = 1
+$_SESSION['isAdmin'] = true; // Temporär
+
+
 ?>
 
 <html lang="en">
@@ -95,6 +100,67 @@ try {
 						</a>
 
 						<div class="card-body d-flex flex-column">
+							<!-- Checks if user is logged in -->
+							<?php if (isset($_SESSION['customerId'])): ?>
+
+								<!-- Loads ReviewRepository and checks if user already reviewed this artwork -->
+								<?php
+								require_once dirname(__DIR__) . "/src/repositories/ReviewRepository.php";
+								$reviewRepo = new ReviewRepository($db);
+								$alreadyReviewed = $reviewRepo->hasUserReviewed($_SESSION['customerId'], $artwork->getArtworkId());
+								?>
+
+								<!-- Displays review form if user has not reviewed yet -->
+								<?php if (!$alreadyReviewed): ?>
+									<form method="POST" action="add-review.php" class="mt-2">
+										<input type="hidden" name="artworkId" value="<?= $artwork->getArtworkId() ?>">
+										<label for="rating">Rating (1–5):</label>
+										<input type="number" name="rating" min="1" max="5" required class="form-control mb-1">
+										<label for="comment">Comment:</label>
+										<textarea name="comment" required class="form-control mb-2"></textarea>
+										<button type="submit" class="btn btn-sm btn-success">Submit Review</button>
+									</form>
+									<!-- Message if user has already submitted a review -->
+								<?php else: ?>
+									<p class="text-muted mt-2">You have already reviewed this artwork.</p>
+								<?php endif; ?>
+
+								<!-- Message if user is not logged in -->
+							<?php else: ?>
+								<p class="text-muted mt-2">Log in to leave a review.</p>
+							<?php endif; ?>
+
+							<!-- Loads and displays all reviews for this artwork -->
+							<?php
+							$reviews = $reviewRepo->getAllReviewsForArtwork($artwork->getArtworkId());
+							?>
+
+							<!-- If there are reviews, display them -->
+							<?php if (count($reviews) > 0): ?>
+								<div class="mt-3">
+									<h6>Reviews:</h6>
+									<?php foreach ($reviews as $review): ?>
+										<div class="border rounded p-2 mb-2 bg-light">
+											<strong>Rating:</strong> <?= $review->getRating() ?>/5<br>
+											<strong>Comment:</strong> <?= htmlspecialchars($review->getComment()) ?><br>
+											<small class="text-muted"><?= $review->getReviewDate() ?></small>
+											<!-- Show Delete button only for admins -->
+											<?php if ($_SESSION['isAdmin'] ?? false): ?>
+												<form method="POST" action="delete-review.php" onsubmit="return confirm('Are you sure you want to delete this review?')">
+													<input type="hidden" name="reviewId" value="<?= $review->getReviewId() ?>">
+													<input type="hidden" name="artworkId" value="<?= $review->getArtworkId() ?>">
+													<button type="submit" class="btn btn-sm btn-danger mt-2">Delete</button>
+												</form>
+											<?php endif; ?>
+
+										</div>
+									<?php endforeach; ?>
+								</div>
+								<!-- If no reviews exist -->
+							<?php else: ?>
+								<p class="text-muted mt-2">No reviews yet.</p>
+							<?php endif; ?>
+
 							<h5 class="card-title text-center">
 								<a href="<?php echo $artworkLink ?>" target="_blank" class="text-body">
 									<?php echo $artwork->getTitle() ?>

--- a/display-single-artwork.php
+++ b/display-single-artwork.php
@@ -1,0 +1,94 @@
+<?php
+session_start();
+$_SESSION['customerId'] = 1; // TEMP: simulate logged-in user
+$_SESSION['isAdmin'] = true; // TEMP: simulate admin privileges
+
+require_once "bootstrap.php";
+require_once "classes/Artwork.php";
+require_once "classes/Artist.php";
+require_once "repositories/ArtworkRepository.php";
+require_once "repositories/ArtistRepository.php";
+require_once "repositories/ReviewRepository.php";
+require_once "head.php";
+require_once "navbar.php";
+
+// Check if 'id' is set and valid in the URL
+if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
+    header("Location: error.php?error=invalidParam");
+    exit;
+}
+
+$artworkId = (int)$_GET['id'];
+
+$db = new Database();
+$artworkRepo = new ArtworkRepository($db);
+$artistRepo = new ArtistRepository($db);
+$reviewRepo = new ReviewRepository($db);
+
+// Load artwork, artist and reviews
+try {
+    $artwork = $artworkRepo->findById($artworkId);
+    $artist = $artistRepo->getArtistById($artwork->getArtistId());
+    $reviews = $reviewRepo->getAllReviewsForArtwork($artworkId);
+} catch (Exception $e) {
+    header("Location: error.php?error=invalidID");
+    exit;
+}
+?>
+
+<body class="container mt-4">
+    <h1><?= htmlspecialchars($artwork->getTitle()) ?></h1>
+    <p><strong>By:</strong> <?= htmlspecialchars($artist->getFirstName() . " " . $artist->getLastName()) ?></p>
+
+    <!-- Display artwork image -->
+    <?php
+    $imagePath = "/assets/images/works/square-medium/" . $artwork->getImageFileName() . ".jpg";
+    $placeholder = "/assets/placeholder/works/square-medium/placeholder.svg";
+    $finalPath = file_exists($_SERVER['DOCUMENT_ROOT'] . $imagePath) ? $imagePath : $placeholder;
+    ?>
+    <img src="<?= $finalPath ?>" alt="<?= $artwork->getTitle() ?>" class="img-fluid mb-3">
+
+    <!-- Review form (only if user is logged in and hasn't reviewed yet) -->
+    <?php if (isset($_SESSION['customerId'])): ?>
+        <?php
+        $alreadyReviewed = $reviewRepo->hasUserReviewed($_SESSION['customerId'], $artworkId);
+        ?>
+        <?php if (!$alreadyReviewed): ?>
+            <form method="POST" action="add-review.php" class="mb-3">
+                <input type="hidden" name="artworkId" value="<?= $artworkId ?>">
+                <label for="rating">Rating (1–5):</label>
+                <input type="number" name="rating" min="1" max="5" required class="form-control mb-2">
+                <label for="comment">Comment:</label>
+                <textarea name="comment" required class="form-control mb-2"></textarea>
+                <button type="submit" class="btn btn-success">Submit Review</button>
+            </form>
+        <?php else: ?>
+            <p class="text-muted">You have already reviewed this artwork.</p>
+        <?php endif; ?>
+    <?php else: ?>
+        <p class="text-muted">Please log in to leave a review.</p>
+    <?php endif; ?>
+
+    <!-- Review list -->
+    <h4>Reviews</h4>
+    <?php if (count($reviews) > 0): ?>
+        <?php foreach ($reviews as $review): ?>
+            <div class="border p-2 mb-2 bg-light">
+                <strong>Rating:</strong> <?= $review->getRating() ?>/5<br>
+                <strong>Comment:</strong> <?= htmlspecialchars($review->getComment()) ?><br>
+                <small class="text-muted"><?= $review->getReviewDate() ?></small>
+                <!-- Show delete option for admins -->
+                <?php if ($_SESSION['isAdmin'] ?? false): ?>
+                    <form method="POST" action="delete-review.php" onsubmit="return confirm('Delete this review?')" class="mt-1">
+                        <input type="hidden" name="reviewId" value="<?= $review->getReviewId() ?>">
+                        <input type="hidden" name="artworkId" value="<?= $review->getArtworkId() ?>">
+                        <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                    </form>
+                <?php endif; ?>
+            </div>
+        <?php endforeach; ?>
+    <?php else: ?>
+        <p class="text-muted">No reviews yet.</p>
+    <?php endif; ?>
+</body>
+</html>

--- a/error.php
+++ b/error.php
@@ -1,26 +1,54 @@
 <!DOCTYPE html>
 <html lang="en">
-<?php
-  if ($_GET['error'] == 'tooShort') {
-      echo "Error 400: Bitte geben Sie in der Suchleiste mindestens 3 Zeichen ein";
-  }
+<head>
+    <title>Error</title>
+    <meta charset="UTF-8">
+</head>
+<body class="container mt-5">
+    <h2>Error</h2>
+    <p>
+        <?php
+        $error = $_GET['error'] ?? '';
 
-if ($_GET['error'] == 'invalidParam') {
-    echo "Error 400: Der übergebene Parameter ist nicht gültig";
-}
-
-if ($_GET['error'] == "missingParam") {
-    echo "Error 400: Bitte übergib einen gültigen Parameter";
-}
-
-if ($_GET['error'] == 'invalidID') {
-    if (isset($_GET['type']) && $_GET['type'] === 'subject') {
-        echo "Error 404: Es konnte kein Thema mit der angegebenen ID gefunden werden";
-    } elseif (isset($_GET['type']) && $_GET['type'] === 'artist') {
-        echo "Error 404: Es konnte kein Künstler mit der angegebenen ID gefunden werden";
-    } else {
-        echo "Error 404: Es konnte kein Eintrag mit der angegebenen ID gefunden werden";
-    }
-}
-?>
+        switch ($error) {
+            case 'tooShort':
+                echo "Error 400: Please enter at least 3 characters in the search bar.";
+                break;
+            case 'invalidParam':
+                echo "Error 400: The passed parameter is invalid.";
+                break;
+            case 'missingParam':
+                echo "Error 400: A required parameter is missing.";
+                break;
+            case 'invalidID':
+                $type = $_GET['type'] ?? '';
+                if ($type === 'subject') {
+                    echo "Error 404: No subject with the given ID was found.";
+                } elseif ($type === 'artist') {
+                    echo "Error 404: No artist with the given ID was found.";
+                } else {
+                    echo "Error 404: No entry with the given ID was found.";
+                }
+                break;
+            case 'notLoggedIn':
+                echo "Error 401: You must be logged in to perform this action.";
+                break;
+            case 'unauthorized':
+                echo "Error 403: You are not authorized to perform this action.";
+                break;
+            case 'missingReviewData':
+                echo "Error 400: Required review data is missing.";
+                break;
+            case 'invalidReviewData':
+                echo "Error 400: Invalid review data submitted.";
+                break;
+            case 'duplicateReview':
+                echo "Error 409: You have already reviewed this artwork.";
+                break;
+            default:
+                echo "An unknown error occurred.";
+        }
+        ?>
+    </p>
+</body>
 </html>

--- a/repositories/ReviewRepository.php
+++ b/repositories/ReviewRepository.php
@@ -91,4 +91,19 @@ public function getAllReviewsForArtwork(int $artworkId): array {
     return $reviews;
 }
 
+/**
+ * Deletes a review by ID
+ */
+public function deleteReview(int $reviewId): void {
+    if (!$this->db->isConnected()) $this->db->connect();
+
+    $sql = "DELETE FROM reviews WHERE ReviewId = :id";
+    $stmt = $this->db->prepareStatement($sql);
+    $stmt->bindValue("id", $reviewId, PDO::PARAM_INT);
+    $stmt->execute();
+
+    $this->db->disconnect();
+}
+
+
 }


### PR DESCRIPTION
## Describe your changes

-  Added a review form under each artwork card on the artist detail page
-  Adjusted constructor parameter order in `Review.php` to match how Review objects are created, so values like customerId, rating, and comment go to the correct fields
-  Validates review submission (rating 1–5, non-empty comment)
-  Prevents duplicate reviews by checking if user already reviewed the artwork
-  Displays all existing reviews below each artwork (including rating, comment, and date)
-  Temporary session-based login simulation (until real login/user management is implemented)
-  Admins can now delete reviews directly under each artwork
-  Delete button is only visible for users with `isAdmin = true`
-  Added the following methods in `ReviewRepository.php`:
  - `addReview()`
  - `hasUserReviewed()`
  - `getAllReviewsForArtwork()`
  - `deleteReview()`
 
## Changes since last update:

- Moved review form and display logic from `display-single-artist.php` to new `display-single-artwork.php` page, as specified in the use case
- The artist page now only links to individual artwork pages

## What does your change implement/impact?

1. Users can now leave a review for any artwork 
2. All submitted reviews are visible under each artwork to all users
3. Admins can delete reviews directly from the UI

## Notes

- Real login & user management will follow in separate use cases (e.g. Register, Login, Manage User)
- Currently using `$_SESSION['customerId'] = 1;` and `$_SESSION['isAdmin'] = true;` to simulate roles
- Tested locally – reviews are saved, displayed, rating and comment must be filled out, correctly blocked if already submitted and can be deleted by admins
- The page to display a single artwork reloads itself after the deletion
- Works as expected

Closes #16 Closes #17